### PR TITLE
Make more logic the filter example in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ var filter = require('gulp-filter');
 gulp.task('default', function () {
 	gulp.src('src/*.js')
 		// filter a subset of the files
-		.pipe(filter('!src/vendor'))
+		.pipe(filter('src/vendor'))
 		// run them through a plugin
 		.pipe(jscs())
 		// bring back the previously filtered out files (optional)


### PR DESCRIPTION
It makes no sense to only call jscs on src/vendor.
The filter() is filtering the pattern you give to him, not the opposite.
