### PR TITLE
Use matchBase to filter by resource type

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,9 @@ var gutil = require('gulp-util');
 var through = require('through2');
 var multimatch = require('multimatch');
 
-module.exports = function (pattern) {
+module.exports = function (pattern, options) {
 	pattern = typeof pattern === 'string' ? [pattern] : pattern;
+	options = options || {};
 
 	if (!Array.isArray(pattern) && typeof pattern !== 'function') {
 		throw new gutil.PluginError('gulp-filter', '`pattern` should be a string, array, or function');
@@ -17,7 +18,7 @@ module.exports = function (pattern) {
 		}
 
 		var match = typeof pattern === 'function' ? pattern(file) :
-		            multimatch(file.relative, pattern, {dot: true}).length > 0;
+		            multimatch(file.relative, pattern, options).length > 0;
 
 		if (match) {
 			this.push(file);

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ gulp.task('default', function () {
 
 ## API
 
-### filter(pattern)
+### filter(pattern, options)
 
 #### pattern
 
@@ -51,6 +51,14 @@ filter(function (file) {
 	return /unicorns/.test(file.path);
 });
 ```
+
+#### options
+
+Type: `Object`
+
+Accepts [minimatch options](https://github.com/isaacs/minimatch#options).
+
+*NOTE*: If you need to match files beginning with a dot (.), you need to supply the `dot: true` options.
 
 ### filter.end()
 

--- a/test.js
+++ b/test.js
@@ -31,6 +31,33 @@ describe('filter()', function () {
 		stream.end();
 	});
 
+	it('should forward multimatch options', function(cb) {
+		var stream = filter('*.js', {matchBase: true});
+		var buffer = [];
+
+		stream.on('data', function (file) {
+			buffer.push(file);
+		});
+
+		stream.on('end', function () {
+			assert.equal(buffer.length, 1);
+			assert.equal(buffer[0].relative, 'nested/resource.js');
+			cb();
+		});
+
+		stream.write(new gutil.File({
+			base: __dirname,
+			path: __dirname + '/nested/resource.js'
+		}));
+
+		stream.write(new gutil.File({
+			base: __dirname,
+			path: __dirname + '/nested/resource.css'
+		}));
+
+		stream.end();
+	});
+
 	it('should filter using a function', function (cb) {
 		var stream = filter(function (file) {
 			return file.path === 'included.js';
@@ -53,7 +80,7 @@ describe('filter()', function () {
 	});
 
 	it('should filter files with negate pattern and leading dot', function (cb) {
-		var stream = filter(['!*.json', '!*rc']);
+		var stream = filter(['!*.json', '!*rc'], {dot: true});
 		var buffer = [];
 
 		stream.on('data', function (file) {


### PR DESCRIPTION
I'm using `gulp-bower-files` to get access to all my vendored assets. I'd like to partition them by file type.

I propose this

```
bowerFiles().pipe(filter('*.js'))
```

rather than

```
bowerFiles().pipe(filter('**/*.js'))
```
