### PR TITLE
Fix filter.end()

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ var multimatch = require('multimatch');
 module.exports = function (pattern) {
 	pattern = typeof pattern === 'string' ? [pattern] : pattern;
 
+	var ignored = [];
+
 	if (!Array.isArray(pattern) && typeof pattern !== 'function') {
 		throw new gutil.PluginError('gulp-filter', '`pattern` should be a string, array, or function');
 	}
@@ -24,8 +26,15 @@ module.exports = function (pattern) {
 			return cb();
 		}
 
-		file.gulpFilter = file.gulpFilter || [];
-		file.gulpFilter.push(file);
+		ignored.push(file);
+		cb();
+	},
+	function(cb) {
+		if(ignored.length > 0) {
+			var file = new gutil.File({path: '.gulp-filter'});
+			file.gulpFilter = ignored;
+			this.push(file);
+		}
 		cb();
 	});
 };

--- a/test.js
+++ b/test.js
@@ -13,8 +13,10 @@ describe('filter()', function () {
 		});
 
 		stream.on('end', function () {
-			assert.equal(buffer.length, 1);
+			assert.equal(buffer.length, 2);
 			assert.equal(buffer[0].relative, 'included.js');
+			assert.equal(buffer[1].relative, '.gulp-filter');
+			assert(buffer[1].isNull());
 			cb();
 		});
 
@@ -42,8 +44,10 @@ describe('filter()', function () {
 		});
 
 		stream.on('end', function () {
-			assert.equal(buffer.length, 1);
+			assert.equal(buffer.length, 2);
 			assert.equal(buffer[0].path, 'included.js');
+			assert.equal(buffer[1].path, '.gulp-filter');
+			assert(buffer[1].isNull());
 			cb();
 		});
 
@@ -61,9 +65,10 @@ describe('filter()', function () {
 		});
 
 		stream.on('end', function () {
-			assert.equal(buffer.length, 2);
+			assert.equal(buffer.length, 3);
 			assert.equal(buffer[0].path, 'included.js');
 			assert.equal(buffer[1].path, 'app.js');
+			assert(buffer[2].isNull());
 			cb();
 		});
 
@@ -81,19 +86,21 @@ describe('filter.end()', function () {
 		var buffer = [];
 		var ignoredFile = new gutil.File({path: 'ignored.js'});
 		var fakeFile = new gutil.File({path: 'new.js'});
-		fakeFile.gulpFilter = [ignoredFile];
+		var gulpFilterFile = new gutil.File({path: '.gulp-filter'});
+		gulpFilterFile.gulpFilter = [ignoredFile];
 
 		stream.on('data', function (file) {
 			buffer.push(file);
 		});
 
 		stream.on('end', function () {
-			assert.equal(buffer[0].path, 'ignored.js');
-			assert.equal(buffer[1].path, 'new.js');
+			assert.equal(buffer[0].path, 'new.js');
+			assert.equal(buffer[1].path, 'ignored.js');
 			cb();
 		});
 
 		stream.write(fakeFile);
+		stream.write(gulpFilterFile);
 		stream.end();
 	});
 });


### PR DESCRIPTION
Prior to this commit, filtered files would not be piped to the next
stream within non-filtered files. So filter.end() would not bring back
filtered files.

This commit buffers ignored files during the filter() phase and pushes
them all within a ".gulp-filter" file with null contents.
This implementation should work with most Gulp plugins, since Gulp
guidelines state that gulp plugins should just push files that verify
file.isNull().

Fixes #2
