### PR TITLE
Allow using restore streams a a single source of file closes #12

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,10 +28,17 @@ module.exports = function (pattern, options) {
 		}
 
 		restoreStream.write(file, cb);
-	});
+	}, function(cb) {
+    restoreStream.end();
+    cb();
+  });
 
-	stream.restore = function () {
-		return restoreStream;
+	stream.restore = function (options) {
+	  options = options || {};
+	  if(options.end) {
+	    return restoreStream;
+	  }
+		return restoreStream.pipe(through.obj(), {end: false});
 	};
 
 	return stream;

--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,33 @@ gulp.task('default', function () {
 });
 ```
 
+### Restore as a file source
+
+You could also want to restore filtered files in a different place and use it
+ as a standalone source of file. The `end` option allow you to do so.
+
+
+```js
+var gulp = require('gulp');
+var jscs = require('gulp-jscs');
+var gulpFilter = require('gulp-filter');
+
+var filter = gulpFilter('!src/vendor');
+
+gulp.task('default', function () {
+	gulp.src('src/*.js')
+		// filter a subset of the files
+		.pipe(filter)
+		// run them through a plugin
+		.pipe(jscs())
+		.pipe(gulp.dest('dist'));
+
+		// use filtered files as a gulp file source
+		filter.restore({end: true})
+  		.pipe(gulp.dest('vendordist'));
+});
+```
+
 
 ## API
 
@@ -90,9 +117,16 @@ Accepts [minimatch options](https://github.com/isaacs/minimatch#options).
 *Note:* Set `dot: true` if you need to match files prefixed with a dot (eg. `.gitignore`).
 
 
-### stream.restore()
+### stream.restore(options)
 
 Brings back the previously filtered out files.
+
+#### options
+
+Type: `Object`
+
+Set `end: true` if you want restore streams to end by themself when their
+ source stream ends.
 
 
 ## License

--- a/test.js
+++ b/test.js
@@ -153,5 +153,26 @@ describe('filter.restore()', function () {
 		streamFilter1.write(new gutil.File({path: 'main.css'}));
 		streamFilter1.end();
 	});
+
+	it('should end when using the end option', function (cb) {
+		var stream = filter('*.json');
+		var restoreStream = stream.restore({end: true});
+		var buffer = [];
+
+		restoreStream.on('data', function (file) {
+			buffer.push(file);
+		});
+
+		restoreStream.on('end', function () {
+			assert.equal(buffer.length, 1);
+			assert.equal(buffer[0].path, 'app.js');
+			cb();
+		});
+
+		stream.write(new gutil.File({path: 'package.json'}));
+		stream.write(new gutil.File({path: 'app.js'}));
+		stream.write(new gutil.File({path: 'package2.json'}));
+		stream.end();
+	});
 });
 


### PR DESCRIPTION
According to this issue https://github.com/sindresorhus/gulp-filter/issues/12
