### PR TITLE
Pass filename relative to cwd to minimatch

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 var gutil = require('gulp-util');
 var through = require('through2');
 var multimatch = require('multimatch');
+var path = require('path');
 
 module.exports = function (pattern, options) {
 	pattern = typeof pattern === 'string' ? [pattern] : pattern;
@@ -15,7 +16,7 @@ module.exports = function (pattern, options) {
 
 	var stream = through.obj(function (file, enc, cb) {
 		var match = typeof pattern === 'function' ? pattern(file) :
-					multimatch(file.relative, pattern, options).length > 0;
+					multimatch(path.relative(file.cwd, file.path), pattern, options).length > 0;
 
 		if (match) {
 			this.push(file);


### PR DESCRIPTION
This retains the fix for #1 while allowing use of `**` in glob
patterns. Making both `**/vendor/**/*.js` and `!*.json` match the
expected files.
