### PR TITLE
Fix deadlock when restore stream is not used. Fix #19

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,8 @@ module.exports = function (pattern, options) {
 			return;
 		}
 
-		restoreStream.write(file, cb);
+		restoreStream.write(file);
+	  	cb();
 	}, function (cb) {
 		restoreStream.end();
 		cb();

--- a/test.js
+++ b/test.js
@@ -174,4 +174,16 @@ describe('filter.restore()', function () {
 		stream.write(new gutil.File({path: 'package2.json'}));
 		stream.end();
 	});
+
+	it('should work when restore stream is not used', function (cb) {
+	  	var stream = filter('*.json');
+	  	for(var i = 0; i < stream._writableState.highWaterMark + 1; i++) {
+		  stream.write(new gutil.File({path: 'nonmatch.js'}));
+		}
+		stream.on('finish', function() {
+		  cb();
+		});
+
+	  	stream.end();
+	});
 });


### PR DESCRIPTION
the callback of stream.write() is invoked only when the object is actually flushed by the underlying stream, this means that if the restoreStream is never used the data will never be flushed causing a deadlock. `write()` will buffer the stream, so there is no point in waiting for the flush anyway.

Fixes #19
