### PR TITLE
Fixed code to use the correct relative path wrt the current working directory.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 var gutil = require('gulp-util');
 var multimatch = require('multimatch');
+var path = require('path');
 var streamfilter = require('streamfilter');
 
 module.exports = function (pattern, options) {
@@ -13,7 +14,7 @@ module.exports = function (pattern, options) {
 
 	return streamfilter(function (file, enc, cb) {
 		var match = typeof pattern === 'function' ? pattern(file) :
-			multimatch(file.relative, pattern, options).length > 0;
+			multimatch(path.relative(file.cwd, file.path), pattern, options).length > 0;
 
 		cb(!match);
 	}, {

--- a/test.js
+++ b/test.js
@@ -131,6 +131,34 @@ describe('filter()', function () {
 		stream.write(new gutil.File({path: 'app.js'}));
 		stream.end();
 	});
+
+	it('should filter with respect to current working directory', function (cb) {
+		var stream = filter('test/**/*.js');
+		var buffer = [];
+
+		stream.on('data', function (file) {
+			buffer.push(file);
+		});
+
+		stream.on('end', function () {
+			assert.equal(buffer.length, 1);
+			assert.equal(buffer[0].relative, 'included.js');
+			cb();
+		});
+
+		// mimic gulp.src('test/**/*.js')
+		stream.write(new gutil.File({
+			base: path.join(__dirname, 'test'),
+			path: path.join(__dirname, 'test', 'included.js')
+		}));
+
+		stream.write(new gutil.File({
+			base: __dirname,
+			path: path.join(__dirname, 'ignored.js')
+		}));
+
+		stream.end();
+	});
 });
 
 describe('filter.restore', function () {


### PR DESCRIPTION
gulp-filter uses `file.relative` to match the pattern, however `file.relative` is not always relative to the current working directory.

When you do `gulp.src('*.js')`, then all files appear to be relative to the current directory. However, if you do `gulp.src('test/**/*.js')`, then all of the files are actually relative to the `test` directory. The relative path is derived from the base path which is resolved via [glob2base](https://www.npmjs.com/package/glob2base). Somewhere something isn’t taking into account the current working directory.

Other gulp plugins such as [gulp-debug](https://github.com/sindresorhus/gulp-debug/blob/master/index.js#L34) have observed this same issue. So the solution is to correctly resolve the relative path with respect to the current working directory, not the base path.

Before this fix, every file would have `src` and `test` absent from the `file.relative` path.

```javascript
gulp.src(['src/**/*.js', 'test/**/*.js'])
    .pipe(...) // do stuff to both src and test files
    .pipe(filter('test/**/*.js')) // no matches :(
    .pipe(...); // do stuff to only test files
```

```javascript
gulp.src(['src/**/*.js', 'test/**/*.js'])
    .pipe(...) // do stuff to both src and test files
    .pipe(filter('**/*.js')) // matches every .js file, but I only wanted test files :(
    .pipe(...); // do stuff to only test files
```

With this fix, you can properly filter patterns such as:

```javascript
gulp.src(['src/**/*.js', 'test/**/*.js'])
    .pipe(...) // do stuff to both src and test files
    .pipe(filter('test/**/*.js'))
    .pipe(...); // do stuff to only test files
```