### PR TITLE
Fix documents with references from #55

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,9 +25,9 @@ const filter = require('gulp-filter');
 
 gulp.task('default', () => {
 	// create filter instance inside task function
-	const f = filter(['*', '!src/vendor']);
+	const f = filter(['**', '!*src/vendor']);
 
-	return gulp.src('src/*.js')
+	return gulp.src('src/**/*.js')
 		// filter a subset of the files
 		.pipe(f)
 		// run them through a plugin
@@ -45,9 +45,9 @@ const filter = require('gulp-filter');
 
 gulp.task('default', () => {
 	// create filter instance inside task function
-	const f = filter(['*', '!src/vendor'], {restore: true});
+	const f = filter(['**', '!*src/vendor'], {restore: true});
 
-	return gulp.src('src/*.js')
+	return gulp.src('src/**/*.js')
 		// filter a subset of the files
 		.pipe(f)
 		// run them through a plugin
@@ -93,9 +93,9 @@ const uglify = require('gulp-uglify');
 const filter = require('gulp-filter');
 
 gulp.task('default', () => {
-	const f = filter(['*', '!src/vendor'], {restore: true, passthrough: false});
+	const f = filter(['**', '!*src/vendor'], {restore: true, passthrough: false});
 
-	const stream = gulp.src('src/*.js')
+	const stream = gulp.src('src/**/*.js')
 		// filter a subset of the files
 		.pipe(f)
 		// run them through a plugin


### PR DESCRIPTION
The examples was incorrected.

* From `'src/*.js'` to `'src/**/*.js'`
* From `'*'` to `'**'`