### PR TITLE
Add useCwd option for a file.relative filtering

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = function (pattern, options) {
 
 	return streamfilter(function (file, enc, cb) {
 		var match = typeof pattern === 'function' ? pattern(file) :
-			multimatch(path.relative(file.cwd, file.path), pattern, options).length > 0;
+			multimatch(!!options.useCwd ? file.relative : path.relative(file.cwd, file.path), pattern, options).length > 0;
 
 		cb(!match);
 	}, {


### PR DESCRIPTION
This would fallback gulp-filter to v3 conditions when needed.