### PR TITLE
Add support for relative parent paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,10 @@ module.exports = function (pattern, options) {
 			match = pattern(file);
 		} else {
 			var relPath = path.relative(file.cwd, file.path);
-			if (relPath.indexOf('..') === 0) {
+			// if the path leaves the current working directory, then we need to
+			// resolve the absolute path so that the path can be properly matched
+			// by minimatch (via multimatch)
+			if (relPath.indexOf('../') === 0) {
 				relPath = path.resolve(relPath);
 			}
 			match = multimatch(relPath, pattern, options).length > 0;

--- a/index.js
+++ b/index.js
@@ -13,8 +13,16 @@ module.exports = function (pattern, options) {
 	}
 
 	return streamfilter(function (file, enc, cb) {
-		var match = typeof pattern === 'function' ? pattern(file) :
-			multimatch(path.relative(file.cwd, file.path), pattern, options).length > 0;
+		var match;
+		if (typeof pattern === 'function') {
+			match = pattern(file);
+		} else {
+			var relPath = path.relative(file.cwd, file.path);
+			if (relPath.indexOf('..') === 0) {
+				relPath = path.resolve(relPath);
+			}
+			match = multimatch(relPath, pattern, options).length > 0;
+		}
 
 		cb(!match);
 	}, {

--- a/test.js
+++ b/test.js
@@ -160,6 +160,28 @@ describe('filter()', function () {
 
 		stream.end();
 	});
+
+	it('should filter relative paths that leave current directory tree', function (cb) {
+		var stream = filter('**/test/**/*.js');
+		var buffer = [];
+		var gfile = path.join('..', '..', 'test', 'included.js');
+
+		stream.on('data', function (file) {
+			buffer.push(file);
+		});
+
+		stream.on('end', function () {
+			assert.equal(buffer.length, 1);
+			assert.equal(buffer[0].relative, gfile);
+			cb();
+		});
+
+		stream.write(new gutil.File({
+			path: gfile
+		}));
+
+		stream.end();
+	});
 });
 
 describe('filter.restore', function () {


### PR DESCRIPTION
With this fix, paths can now reference files outside the current working directory. So now, the pattern `**/*.js` will match `../../some/file.js`

The only caveat is your pattern has to start with `**` to match the resolved absolute paths of relative parent paths. In other words, you must do`**/test/**/*.js` in order to match `../../test/file.js` and not match `../../src/code.js`. This is a limitation of minimatch, not gulp-filter, gulp, or this PR.

Fixes #74.