### PR TITLE
Update plugin-error@^1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "dependencies": {
     "multimatch": "^2.0.0",
-    "plugin-error": "^0.1.2",
+    "plugin-error": "^1.0.1",
     "streamfilter": "^1.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
I am creating PRs to update all Gulp plugins I used to plugin-error@^1.0.1 to finally prune the version 0.x.y 😅 It should be pretty safe update: https://github.com/gulpjs/plugin-error/releases

Thanks for all your open source work 💕 