### PR TITLE
Fix behavior for matching paths outside cwd

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,8 @@ module.exports = (pattern, options = {}) => {
 		if (typeof pattern === 'function') {
 			match = pattern(file);
 		} else {
+			// path.resolve after toAbsoluteGlob for removing .. from path
+			// this is useful for ../A/B cases
 			const patterns = pattern.map(pattern => toAbsoluteGlob(pattern, {cwd: file.cwd, root: options.root}))
 				.map(pattern => pattern[0] === '!' ? '!' + path.resolve(pattern.slice(1)) : path.resolve(pattern));
 

--- a/index.js
+++ b/index.js
@@ -1,14 +1,14 @@
 'use strict';
+const path = require('path');
 const PluginError = require('plugin-error');
 const multimatch = require('multimatch');
-const path = require('path');
 const streamfilter = require('streamfilter');
 const toAbsoluteGlob = require('to-absolute-glob');
 
 /**
- * @param {string | string[]|function(string):boolean} pattern
- * @param {object} options
- * @returns {Stream}
+ * @param {string | string[]|function(string):boolean} pattern function or glob pattern or array of glob patterns to filter files
+ * @param {object} options see minimatch options, also root option for path resolving
+ * @returns {Stream} Transform stream of Vinyl files
  */
 module.exports = (pattern, options = {}) => {
 	pattern = typeof pattern === 'string' ? [pattern] : pattern;
@@ -23,7 +23,7 @@ module.exports = (pattern, options = {}) => {
 		if (typeof pattern === 'function') {
 			match = pattern(file);
 		} else {
-			// path.resolve after toAbsoluteGlob for removing .. from path
+			// Calling path.resolve after toAbsoluteGlob is required for removing .. from path
 			// this is useful for ../A/B cases
 			const patterns = pattern.map(pattern => toAbsoluteGlob(pattern, {cwd: file.cwd, root: options.root}))
 				.map(pattern => pattern[0] === '!' ? '!' + path.resolve(pattern.slice(1)) : path.resolve(pattern));

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 const PluginError = require('plugin-error');
 const multimatch = require('multimatch');
+const path = require('path');
 const streamfilter = require('streamfilter');
 const toAbsoluteGlob = require('to-absolute-glob');
 
@@ -22,8 +23,10 @@ module.exports = (pattern, options = {}) => {
 		if (typeof pattern === 'function') {
 			match = pattern(file);
 		} else {
-			const patterns = pattern.map(pattern => toAbsoluteGlob(pattern, {cwd: file.cwd, root: options.root}));
-			match = multimatch(file.path, patterns, options);
+			const patterns = pattern.map(pattern => toAbsoluteGlob(pattern, {cwd: file.cwd, root: options.root}))
+				.map(pattern => pattern[0] === '!' ? '!' + path.resolve(pattern.slice(1)) : path.resolve(pattern));
+
+			match = multimatch(file.path, patterns, options).length > 0;
 		}
 
 		callback(!match);

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
 	"dependencies": {
 		"multimatch": "^4.0.0",
 		"plugin-error": "^1.0.1",
-		"streamfilter": "^3.0.0"
+		"streamfilter": "^3.0.0",
+		"to-absolute-glob": "^2.0.2"
 	},
 	"devDependencies": {
 		"mocha": "^6.2.0",

--- a/test.js
+++ b/test.js
@@ -324,7 +324,7 @@ describe('filter.restore', () => {
 // 3) starting with just path, like abcd/<...> or **/**.js - relative path mapping, cwd prepended
 // same rules for !
 
-describe('base matching', () => {
+describe('path matching', () => {
 	const testFilesPaths = [
 		'/test.js',
 		'/A/test.js',
@@ -336,6 +336,16 @@ describe('base matching', () => {
 	const testFiles = testFilesPaths.map(path => new Vinyl({cwd: '/A/B', path}));
 
 	const testCases = [
+		{
+			description: 'Filename by suffix',
+			pattern: ['*.js'],
+			expectedFiles: testFiles
+		},
+		{
+			description: 'Filename by suffix, excluding d.js',
+			pattern: ['*.js', '!d.js'],
+			expectedFiles: testFiles.slice(0, -1)
+		},
 		{
 			description: 'Absolute filter by suffix',
 			pattern: ['/**/*.js'],

--- a/test.js
+++ b/test.js
@@ -322,7 +322,7 @@ describe('filter.restore', () => {
 // 1) starting with / - absolute path matching
 // 2) starting with .. - relative path mapping, cwd prepended
 // 3) starting with just path, like abcd/<...> or **/**.js - relative path mapping, cwd prepended
-// special case: matching starting with !
+// same rules for !
 
 describe('base matching', () => {
 	const testFilesPaths = [
@@ -378,22 +378,22 @@ describe('base matching', () => {
 		},
 		{
 			description: 'Absolute filter starting with !',
-			pattern: ['!/**/*.js'],
+			pattern: ['/**/*', '!/**/*.js'],
 			expectedFiles: []
 		},
 		{
 			description: 'Absolute filter starting with !, filters out all test.js',
-			pattern: ['!/**/test.js'],
+			pattern: ['/**/*', '!/**/test.js'],
 			expectedFiles: [testFiles[5]]
 		},
 		{
-			description: 'Absolute filter starting with !, / omitted',
-			pattern: ['!**/test.js'],
-			expectedFiles: [testFiles[5]]
+			description: 'Absolute filter starting with !, . omitted',
+			pattern: ['/**/*', '!**/*.js'],
+			expectedFiles: testFiles.slice(0, 3)
 		},
 		{
-			description: 'Relative filter starting with !, . required',
-			pattern: ['!./**/*.js'],
+			description: 'Relative filter starting with !, with .',
+			pattern: ['/**/*', '!./**/*.js'],
 			expectedFiles: testFiles.slice(0, 3)
 		},
 		{

--- a/test.js
+++ b/test.js
@@ -331,7 +331,7 @@ describe('base matching', () => {
 		'/A/C/test.js',
 		'/A/B/test.js',
 		'/A/B/C/test.js',
-		'/A/B/C/d.js',
+		'/A/B/C/d.js'
 	];
 	const testFiles = testFilesPaths.map(path => new Vinyl({cwd: '/A/B', path}));
 
@@ -415,10 +415,11 @@ describe('base matching', () => {
 			description: 'Mixed filters: relative filter take files, when relative negated filter rejects',
 			pattern: ['**/*.js', '!./C/**/*.js'],
 			expectedFiles: testFiles.slice(3, 4)
-		},
+		}
 	];
+
 	for (const testCase of testCases) {
-		it('Should ' + testCase.description, (cb) => {
+		it('Should ' + testCase.description, cb => {
 			const stream = filter(testCase.pattern);
 
 			testFiles.forEach(file => stream.write(file));
@@ -434,4 +435,4 @@ describe('base matching', () => {
 			stream.end();
 		});
 	}
-})
+});

--- a/test.js
+++ b/test.js
@@ -392,13 +392,8 @@ describe('base matching', () => {
 			expectedFiles: [testFiles[5]]
 		},
 		{
-			description: 'Filename filter starting with !',
-			pattern: ['!test.js'],
-			expectedFiles: [testFiles[5]]
-		},
-		{
 			description: 'Relative filter starting with !, . required',
-			pattern: ['!./**/**/*.js'],
+			pattern: ['!./**/*.js'],
 			expectedFiles: testFiles.slice(0, 3)
 		},
 		{


### PR DESCRIPTION
Fixes #85 (not sure, maybe #87 too)
Here breaking changes:
Old behavior:
all paths, which is outside of current working directory, should be matched only by absolute path glob

New behavior:
you can match dirs outside current working dir
if you want match globally - start glob pattern with /

Removed test "should filter relative paths that leave current directory tree", because of breaking change


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#85: Filtering files with paths outside of gulp folder not possible?](https://issuehunt.io/repos/15827909/issues/85)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->