### PR TITLE
Migrate to ESM with updated dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,12 +10,11 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 16
-          - 14
-          - 12
+          - 20
+          - 18
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/index.js
+++ b/index.js
@@ -1,11 +1,10 @@
-'use strict';
-const path = require('path');
-const PluginError = require('plugin-error');
-const multimatch = require('multimatch');
-const streamfilter = require('streamfilter');
-const toAbsoluteGlob = require('to-absolute-glob');
+import path from 'node:path';
+import PluginError from 'plugin-error';
+import multimatch from 'multimatch';
+import streamfilter from 'streamfilter';
+import toAbsoluteGlob from 'to-absolute-glob';
 
-module.exports = (pattern, options = {}) => {
+export default function plugin(pattern, options = {}) {
 	pattern = typeof pattern === 'string' ? [pattern] : pattern;
 
 	if (!Array.isArray(pattern) && typeof pattern !== 'function') {
@@ -47,6 +46,6 @@ module.exports = (pattern, options = {}) => {
 	}, {
 		objectMode: true,
 		passthrough: options.passthrough !== false,
-		restore: options.restore
+		restore: options.restore,
 	});
-};
+}

--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
 		"email": "sindresorhus@gmail.com",
 		"url": "https://sindresorhus.com"
 	},
+	"type": "module",
 	"engines": {
-		"node": ">=12"
+		"node": ">=18"
 	},
 	"scripts": {
 		"test": "xo && mocha"
@@ -32,15 +33,15 @@
 		"vinyl"
 	],
 	"dependencies": {
-		"multimatch": "^5.0.0",
-		"plugin-error": "^1.0.1",
+		"multimatch": "^6.0.0",
+		"plugin-error": "^2.0.1",
 		"streamfilter": "^3.0.0",
-		"to-absolute-glob": "^2.0.2"
+		"to-absolute-glob": "^3.0.0"
 	},
 	"devDependencies": {
-		"mocha": "^8.3.2",
-		"vinyl": "^2.2.1",
-		"xo": "^0.39.1"
+		"mocha": "^10.2.0",
+		"vinyl": "^3.0.0",
+		"xo": "^0.55.0"
 	},
 	"peerDependencies": {
 		"gulp": ">=4"

--- a/readme.md
+++ b/readme.md
@@ -17,9 +17,9 @@ $ npm install --save-dev gulp-filter
 You may want to just filter the stream content:
 
 ```js
-const gulp = require('gulp');
-const uglify = require('gulp-uglify');
-const filter = require('gulp-filter');
+import gulp from 'gulp';
+import uglify from 'gulp-uglify';
+import filter from 'gulp-filter';
 
 exports.default = () => {
 	// Create filter instance inside task function
@@ -37,11 +37,11 @@ exports.default = () => {
 ### Restoring filtered files
 
 ```js
-const gulp = require('gulp');
-const uglify = require('gulp-uglify');
-const filter = require('gulp-filter');
+import gulp 'gulp';
+import uglify 'gulp-uglify';
+import filter 'gulp-filter';
 
-exports.default = () => {
+export default () => {
 	// Create filter instance inside task function
 	const f = filter(['**', '!*src/vendor'], {restore: true});
 
@@ -61,12 +61,12 @@ exports.default = () => {
 By combining and restoring different filters you can process different sets of files with a single pipeline.
 
 ```js
-const gulp = require('gulp');
-const less = require('gulp-less');
-const concat = require('gulp-concat');
-const filter = require('gulp-filter');
+import gulp from 'gulp';
+import less from 'gulp-less';
+import concat from 'gulp-concat';
+import filter from 'gulp-filter';
 
-exports.default = () => {
+export default () => {
 	const jsFilter = filter('**/*.js', {restore: true});
 	const lessFilter = filter('**/*.less', {restore: true});
 
@@ -86,11 +86,11 @@ exports.default = () => {
 You can restore filtered files in a different place and use it as a standalone source of files (ReadableStream). Setting the `passthrough` option to `false` allows you to do so.
 
 ```js
-const gulp = require('gulp');
-const uglify = require('gulp-uglify');
-const filter = require('gulp-filter');
+import gulp 'gulp';
+import uglify 'gulp-uglify';
+import filter 'gulp-filter';
 
-exports.default = () => {
+export default () => {
 	const f = filter(['**', '!*src/vendor'], {restore: true, passthrough: false});
 
 	const stream = gulp.src('src/**/*.js')

--- a/test.js
+++ b/test.js
@@ -1,9 +1,11 @@
-'use strict';
 /* eslint-env mocha */
-const path = require('path');
-const {strict: assert} = require('assert');
-const Vinyl = require('vinyl');
-const filter = require('./index.js');
+import {fileURLToPath} from 'node:url';
+import path from 'node:path';
+import {strict as assert} from 'node:assert';
+import Vinyl from 'vinyl';
+import filter from './index.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 describe('filter()', () => {
 	it('should filter files', cb => {
@@ -22,12 +24,12 @@ describe('filter()', () => {
 
 		stream.write(new Vinyl({
 			base: __dirname,
-			path: path.join(__dirname, 'included.js')
+			path: path.join(__dirname, 'included.js'),
 		}));
 
 		stream.write(new Vinyl({
 			base: __dirname,
-			path: path.join(__dirname, 'ignored.js')
+			path: path.join(__dirname, 'ignored.js'),
 		}));
 
 		stream.end();
@@ -50,12 +52,12 @@ describe('filter()', () => {
 
 			stream.write(new Vinyl({
 				base: __dirname,
-				path: path.join(__dirname, 'included.js')
+				path: path.join(__dirname, 'included.js'),
 			}));
 
 			stream.write(new Vinyl({
 				base: __dirname,
-				path: path.join(__dirname, 'ignored.js')
+				path: path.join(__dirname, 'ignored.js'),
 			}));
 
 			stream.end();
@@ -78,12 +80,12 @@ describe('filter()', () => {
 
 		stream.write(new Vinyl({
 			base: __dirname,
-			path: path.join(__dirname, 'nested', 'resource.js')
+			path: path.join(__dirname, 'nested', 'resource.js'),
 		}));
 
 		stream.write(new Vinyl({
 			base: __dirname,
-			path: path.join(__dirname, 'nested', 'resource.css')
+			path: path.join(__dirname, 'nested', 'resource.css'),
 		}));
 
 		stream.end();
@@ -148,12 +150,12 @@ describe('filter()', () => {
 		// Mimic `gulp.src('test/**/*.js')`
 		stream.write(new Vinyl({
 			base: path.join(__dirname, 'test'),
-			path: path.join(__dirname, 'test', 'included.js')
+			path: path.join(__dirname, 'test', 'included.js'),
 		}));
 
 		stream.write(new Vinyl({
 			base: __dirname,
-			path: path.join(__dirname, 'ignored.js')
+			path: path.join(__dirname, 'ignored.js'),
 		}));
 
 		stream.end();
@@ -330,7 +332,7 @@ describe('path matching', () => {
 		'/A/C/test.js',
 		'/A/B/test.js',
 		'/A/B/C/test.js',
-		'/A/B/C/d.js'
+		'/A/B/C/d.js',
 	];
 
 	const testFiles = testFilesPaths.map(path => new Vinyl({cwd: '/A/B', path}));
@@ -339,93 +341,93 @@ describe('path matching', () => {
 		{
 			description: 'Filename by suffix',
 			pattern: ['*.js'],
-			expectedFiles: testFiles
+			expectedFiles: testFiles,
 		},
 		{
 			description: 'Filename by suffix, excluding d.js',
 			pattern: ['*.js', '!d.js'],
-			expectedFiles: testFiles.slice(0, -1)
+			expectedFiles: testFiles.slice(0, -1),
 		},
 		{
 			description: 'Absolute filter by suffix',
 			pattern: ['/**/*.js'],
-			expectedFiles: testFiles
+			expectedFiles: testFiles,
 		},
 		{
 			description: 'Absolute filter by suffix with prefix',
 			pattern: ['/A/**/*.js'],
-			expectedFiles: testFiles.slice(1)
+			expectedFiles: testFiles.slice(1),
 		},
 		{
 			description: 'Absolute filter by suffix with prefix equal to base',
 			pattern: ['/A/B/**/*.js'],
-			expectedFiles: testFiles.slice(3)
+			expectedFiles: testFiles.slice(3),
 		},
 		{
 			description: 'Relative filter',
 			pattern: ['**/*.js'],
-			expectedFiles: testFiles.slice(3)
+			expectedFiles: testFiles.slice(3),
 		},
 		{
 			description: 'Relative filter but explicit',
 			pattern: ['./**/*.js'],
-			expectedFiles: testFiles.slice(3)
+			expectedFiles: testFiles.slice(3),
 		},
 		{
 			description: 'Relative filter with .. prefix',
 			pattern: ['../**/*.js'],
-			expectedFiles: testFiles.slice(1)
+			expectedFiles: testFiles.slice(1),
 		},
 		{
 			description: 'Relative filter with path prefix',
 			pattern: ['C/**/*.js'],
-			expectedFiles: testFiles.slice(4)
+			expectedFiles: testFiles.slice(4),
 		},
 		{
 			description: 'Relative filter with path prefix, but then ..',
 			pattern: ['C/../**/*.js'],
-			expectedFiles: testFiles.slice(3)
+			expectedFiles: testFiles.slice(3),
 		},
 		{
 			description: 'Absolute filter starting with !',
 			pattern: ['/**/*', '!/**/*.js'],
-			expectedFiles: []
+			expectedFiles: [],
 		},
 		{
 			description: 'Absolute filter starting with !, filters out all test.js',
 			pattern: ['/**/*', '!/**/test.js'],
-			expectedFiles: [testFiles[5]]
+			expectedFiles: [testFiles[5]],
 		},
 		{
 			description: 'Absolute filter starting with !, . omitted',
 			pattern: ['/**/*', '!**/*.js'],
-			expectedFiles: testFiles.slice(0, 3)
+			expectedFiles: testFiles.slice(0, 3),
 		},
 		{
 			description: 'Relative filter starting with !, with .',
 			pattern: ['/**/*', '!./**/*.js'],
-			expectedFiles: testFiles.slice(0, 3)
+			expectedFiles: testFiles.slice(0, 3),
 		},
 		{
 			description: 'Mixed filters: absolute filter take files, when absolute negated filter rejects',
 			pattern: ['/A/**/*.js', '!/A/B/**/*.js'],
-			expectedFiles: testFiles.slice(1, 3)
+			expectedFiles: testFiles.slice(1, 3),
 		},
 		{
 			description: 'Mixed filters: relative filter take files, when absolute negated filter rejects',
 			pattern: ['**/*.js', '!/A/B/C/**/*.js'],
-			expectedFiles: testFiles.slice(3, 4)
+			expectedFiles: testFiles.slice(3, 4),
 		},
 		{
 			description: 'Mixed filters: absolute filter take files, when relative negated filter rejects',
 			pattern: ['/A/**/*.js', '!./C/**/*.js'],
-			expectedFiles: testFiles.slice(1, 4)
+			expectedFiles: testFiles.slice(1, 4),
 		},
 		{
 			description: 'Mixed filters: relative filter take files, when relative negated filter rejects',
 			pattern: ['**/*.js', '!./C/**/*.js'],
-			expectedFiles: testFiles.slice(3, 4)
-		}
+			expectedFiles: testFiles.slice(3, 4),
+		},
 	];
 
 	for (const testCase of testCases) {


### PR DESCRIPTION
- Update all dependencies
- Fix all the linter errors
- Move from CJS to ESM
- Bump minimum Node to 18 and above (considering how often this package is updated, it's fine?)

The tests are passing in my fork https://github.com/pioug/gulp-filter/actions/runs/5621361228. Just one warning reported by linter. It's in `test.js` so it should be good enough.

```
  test.js:256:19
  ⚠  256:19  Too many nested callbacks (5). Maximum allowed is 4.  max-nested-callbacks

  1 warning
```